### PR TITLE
Fixing performance issues caused by exessive use of spawn_child

### DIFF
--- a/src/__fixtures__/diff.ts
+++ b/src/__fixtures__/diff.ts
@@ -45,3 +45,10 @@ index cb3c131..874b8f9 100644
 @@ -17,2 +16,0 @@ import { a } from "../components/a";
 -import { b } from "../context/b";
 -import { c } from "../context/c";`;
+
+export const filenamesAB = `a/dirty.js
+b/dirty.js
+`;
+
+export const filenamesA = `a/dirty.js
+`

--- a/src/__snapshots__/index.test.ts.snap
+++ b/src/__snapshots__/index.test.ts.snap
@@ -62,10 +62,12 @@ Object {
     "processors": Object {
       "diff": Object {
         "postprocess": [Function],
+        "preprocess": [Function],
         "supportsAutofix": true,
       },
       "staged": Object {
         "postprocess": [Function],
+        "preprocess": [Function],
         "supportsAutofix": true,
       },
     },
@@ -73,10 +75,12 @@ Object {
   "processors": Object {
     "diff": Object {
       "postprocess": [Function],
+      "preprocess": [Function],
       "supportsAutofix": true,
     },
     "staged": Object {
       "postprocess": [Function],
+      "preprocess": [Function],
       "supportsAutofix": true,
     },
   },

--- a/src/git.test.ts
+++ b/src/git.test.ts
@@ -1,7 +1,8 @@
 import * as child_process from "child_process";
 import { mocked } from "ts-jest/utils";
-import { getDiffForFile, getRangesForDiff } from "./git";
-import { hunks, includingOnlyRemovals } from "./__fixtures__/diff";
+import { getDiffFileList, getDiffForFile, getRangesForDiff } from "./git";
+import { hunks, includingOnlyRemovals, filenamesAB } from "./__fixtures__/diff";
+import path from "path";
 
 jest.mock("child_process");
 
@@ -37,5 +38,16 @@ describe("git", () => {
 
     getDiffForFile("./mockfileMiss.js");
     expect(mockedChildProcess.execSync).toHaveBeenCalledTimes(2);
+  });
+
+  it("should get the list of staged files", () => {
+    mockedChildProcess.execSync.mockReturnValue(Buffer.from(filenamesAB));
+
+    const fileList = getDiffFileList();
+
+    expect(mockedChildProcess.execSync).toHaveBeenCalled();
+    expect(fileList).toEqual(
+      ["a/dirty.js", "b/dirty.js"].map((p) => path.resolve(p))
+    );
   });
 });

--- a/src/git.test.ts
+++ b/src/git.test.ts
@@ -25,4 +25,17 @@ describe("git", () => {
     expect(diffFromFile).toContain("diff --git");
     expect(diffFromFile).toContain("@@");
   });
+
+  it("should hit the cached diff of a file", () => {
+    jest.mock("child_process").resetAllMocks();
+    mockedChildProcess.execSync.mockReturnValue(Buffer.from(hunks));
+
+    const diffFromFileA = getDiffForFile("./mockfileCache.js");
+    const diffFromFileB = getDiffForFile("./mockfileCache.js");
+    expect(mockedChildProcess.execSync).toHaveBeenCalledTimes(1);
+    expect(diffFromFileA).toEqual(diffFromFileB);
+
+    getDiffForFile("./mockfileMiss.js");
+    expect(mockedChildProcess.execSync).toHaveBeenCalledTimes(2);
+  });
 });

--- a/src/git.ts
+++ b/src/git.ts
@@ -21,13 +21,24 @@ const getDiffForFile = (filePath: string, staged = false): string => {
     const diff = child_process
       .execSync(
         `git diff --diff-filter=ACM --unified=0 HEAD ${
-          staged ? " --staged" : ""
+          staged ? "--staged" : ""
         } -- ${sanitizeFilePath(filePath)}`
       )
       .toString();
     diffCache.set(diffCacheKey(filePath, staged), diff);
     return diff;
   }
+};
+
+const getDiffFileList = (staged = false): string[] => {
+  return child_process
+    .execSync(
+      `git diff --diff-filter=ACM HEAD ${staged ? "--staged" : ""} --name-only`
+    )
+    .toString()
+    .split("\n")
+    .filter((filePath) => filePath.length)
+    .map((filePath) => path.resolve(filePath));
 };
 
 const isHunkHeader = (input: string) => {
@@ -73,5 +84,5 @@ const getRangesForDiff = (diff: string): Range[] => {
     .filter(removeNullRanges);
 };
 
-export { getDiffForFile, getRangesForDiff };
+export { getDiffForFile, getRangesForDiff, getDiffFileList };
 export type { Range };

--- a/src/processors.ts
+++ b/src/processors.ts
@@ -1,12 +1,31 @@
-import { getDiffForFile, getRangesForDiff, Range } from "./git";
+import {
+  getDiffForFile,
+  getRangesForDiff,
+  getDiffFileList,
+  Range,
+} from "./git";
 import { Linter } from "eslint";
 
 const STAGED = true;
 
 const isLineWithinRange = (line: number) => (range: Range) =>
   range.isWithinRange(line);
+let fileList: string[];
 
 const diff = {
+  preprocess: (
+    text: string,
+    filename: string
+  ): { text: string; filename: string }[] => {
+    if (
+      (fileList ? fileList : (fileList = getDiffFileList())).includes(filename)
+    ) {
+      return [{ text, filename }];
+    } else {
+      return [];
+    }
+  },
+
   postprocess: (
     messages: Linter.LintMessage[][],
     filename: string
@@ -35,6 +54,20 @@ const diffConfig = {
 };
 
 const staged = {
+  preprocess: (
+    text: string,
+    filename: string
+  ): { text: string; filename: string }[] => {
+    if (
+      (fileList ? fileList : (fileList = getDiffFileList(true))).includes(
+        filename
+      )
+    ) {
+      return [{ text, filename }];
+    } else {
+      return [];
+    }
+  },
   postprocess: (
     messages: Linter.LintMessage[][],
     filename: string


### PR DESCRIPTION
Hey, 
to fix the Problem mentioned in issue #2 i implemented memoization for the git `getDiffForFile` function.
also added a preprocess function to basicly excludes files from linting which are untouched.

Tests are updated.