### PR TITLE
Feature/fix vscode eslint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.tsbuildinfo
 /coverage/
 /dist/
+/node_modules

--- a/src/processors.test.ts
+++ b/src/processors.test.ts
@@ -16,17 +16,15 @@ mockedChildProcess.execSync.mockReturnValue(Buffer.from(mockFilename));
 const mockedGit = mocked(git, true);
 
 // @ts-expect-error todo: fix type error here
-mockedGit.getDiffFileList = jest
-  .fn()
-  .mockReturnValue([mockFilename, "README.md"]);
+mockedGit.getDiffFileList = jest.fn();
 
 const [messages, filename] = postprocessArguments;
 
 describe("processors", () => {
-  it("diff preprocess", () => {
-    const validFilename = filename;
-    const sourceCode = "/** Some source code */";
+  const validFilename = filename;
+  const sourceCode = "/** Some source code */";
 
+  it("diff preprocess", () => {
     mockedChildProcess.execSync.mockReturnValue(Buffer.from(fixtureDiff));
 
     expect(
@@ -34,10 +32,25 @@ describe("processors", () => {
     ).toEqual([sourceCode]);
   });
 
-  it("staged preprocess", () => {
-    const validFilename = filename;
-    const sourceCode = "/** Some source code */";
+  /**
+   * Linked issue: https://github.com/paleite/eslint-plugin-diff/issues/14
+   */
+  it("diff preprocess should not exclude files in a Vscode plugin context", () => {
+    process.env.VSCODE_CLI = "true";
+    process.env.VSCODE_PID = "9293";
 
+    mockedChildProcess.execSync.mockReturnValue(Buffer.from(""));
+
+    expect(
+      diff.preprocess && diff.preprocess(sourceCode, validFilename)
+    ).toEqual([sourceCode]);
+
+    // clean it up
+    process.env.VSCODE_PID = undefined;
+    process.env.VSCODE_CLI = undefined;
+  });
+
+  it("staged preprocess", () => {
     mockedChildProcess.execSync.mockReturnValue(Buffer.from(fixtureDiff));
 
     expect(

--- a/src/processors.test.ts
+++ b/src/processors.test.ts
@@ -14,6 +14,8 @@ const mockedChildProcess = mocked(child_process, true);
 const mockFilename = '/mock filename with quotes ", semicolons ; and spaces.js';
 mockedChildProcess.execSync.mockReturnValue(Buffer.from(mockFilename));
 const mockedGit = mocked(git, true);
+
+// @ts-expect-error todo: fix type error here
 mockedGit.getDiffFileList = jest
   .fn()
   .mockReturnValue([mockFilename, "README.md"]);
@@ -27,7 +29,9 @@ describe("processors", () => {
 
     mockedChildProcess.execSync.mockReturnValue(Buffer.from(fixtureDiff));
 
-    expect(diff.preprocess(sourceCode, validFilename)).toEqual([sourceCode]);
+    expect(
+      diff.preprocess && diff.preprocess(sourceCode, validFilename)
+    ).toEqual([sourceCode]);
   });
 
   it("staged preprocess", () => {
@@ -36,13 +40,17 @@ describe("processors", () => {
 
     mockedChildProcess.execSync.mockReturnValue(Buffer.from(fixtureDiff));
 
-    expect(diff.preprocess(sourceCode, validFilename)).toEqual([sourceCode]);
+    expect(
+      diff.preprocess && diff.preprocess(sourceCode, validFilename)
+    ).toEqual([sourceCode]);
   });
 
   it("diff postprocess", () => {
     mockedChildProcess.execSync.mockReturnValue(Buffer.from(fixtureDiff));
 
-    expect(diff.postprocess(messages, filename)).toMatchSnapshot();
+    expect(
+      diff.postprocess && diff.postprocess(messages, filename)
+    ).toMatchSnapshot();
 
     expect(mockedChildProcess.execSync).toHaveBeenCalled();
   });
@@ -50,7 +58,9 @@ describe("processors", () => {
   it("staged postprocess", () => {
     mockedChildProcess.execSync.mockReturnValue(Buffer.from(fixtureStaged));
 
-    expect(staged.postprocess(messages, filename)).toMatchSnapshot();
+    expect(
+      staged.postprocess && staged.postprocess(messages, filename)
+    ).toMatchSnapshot();
 
     expect(mockedChildProcess.execSync).toHaveBeenCalled();
   });
@@ -64,8 +74,12 @@ describe("processors", () => {
       ...restMessageArray,
     ];
 
-    expect(diff.postprocess(messages, filename)).toHaveLength(2);
-    expect(diff.postprocess(messagesWithFatal, filename)).toHaveLength(3);
+    expect(
+      diff.postprocess && diff.postprocess(messages, filename)
+    ).toHaveLength(2);
+    expect(
+      diff.postprocess && diff.postprocess(messagesWithFatal, filename)
+    ).toHaveLength(3);
 
     expect(mockedChildProcess.execSync).toHaveBeenCalled();
   });

--- a/src/processors.ts
+++ b/src/processors.ts
@@ -11,6 +11,13 @@ import {
 const STAGED = true;
 
 /**
+ * Returns a boolean whether we are in the context
+ * of a Vscode plugin or not.
+ */
+const isVsCodePluginContext = (): boolean =>
+  process.env.VSCODE_PID !== undefined;
+
+/**
  * Exclude unchanged files from being processed
  *
  * Since we're excluding unchanged files in the post-processor, we can exclude
@@ -22,6 +29,7 @@ const getPreProcessor =
   (text: string, filename: string) => {
     const shouldBeProcessed =
       process.env.VSCODE_CLI !== undefined ||
+      isVsCodePluginContext() ||
       !staged ||
       getDiffFileList().includes(filename);
     return shouldBeProcessed ? [text] : [];


### PR DESCRIPTION
Hi there 👋 

I submit this little PR aiming to resolve issue #14 

I dug a bit and noticed that the `VSCODE_PID` was available in the context of the Vscode plugin but not in the context of the classic CLI command (`eslint <options>`). Then I used it to bypass the preprocess check. Let me know WDYT?

I tried locally with my sources files and it seems to work, but I'm not sure at all... I think we should try with an alpha release or something like that.

> ⚠️ I faced a few devx issues when I started my contribution
- node_modules was not ignored from git
- I add a bunch of typescript/eslint errors (the chaining operation was not work 👶)

<img width="907" alt="Screenshot 2022-02-15 at 10 07 47" src="https://user-images.githubusercontent.com/22824417/154050527-51dd6b5c-3df6-4fb4-8aec-d0f2b4e39b43.png">

I tried to fix them as I can to submit something.

Moreover, this test fail in my local environment:

![Screenshot 2022-02-15 at 12 11 39](https://user-images.githubusercontent.com/22824417/154050798-08f83fe3-4aeb-4ddc-bba9-1b7b987ae372.png)


 