### PR TITLE
Add --no-ext-diff to git diff commands

### DIFF
--- a/src/git.test.ts
+++ b/src/git.test.ts
@@ -56,7 +56,7 @@ describe("getDiffForFile", () => {
 
     const expectedCommand = "git";
     const expectedArgs =
-      'diff --diff-algorithm=histogram --diff-filter=ACM -M100% --relative --staged --unified=0 1234567';
+      'diff --no-ext-diff --diff-algorithm=histogram --diff-filter=ACM -M100% --relative --staged --unified=0 1234567';
 
     const lastCall = mockedChildProcess.execFileSync.mock.calls.at(-1);
     const [command, argsIncludingFile = []] = lastCall ?? [""];

--- a/src/git.ts
+++ b/src/git.ts
@@ -7,6 +7,7 @@ const COMMAND = "git";
 const getDiffForFile = (filePath: string, staged = false): string => {
   const args = [
     "diff",
+    "--no-ext-diff",
     "--diff-algorithm=histogram",
     "--diff-filter=ACM",
     "-M100%",
@@ -27,6 +28,7 @@ const getDiffForFile = (filePath: string, staged = false): string => {
 const getDiffFileList = (): string[] => {
   const args = [
     "diff",
+    "--no-ext-diff",
     "--diff-algorithm=histogram",
     "--diff-filter=ACM",
     "-M100%",
@@ -47,6 +49,7 @@ const getDiffFileList = (): string[] => {
 const hasCleanIndex = (filePath: string): boolean => {
   const args = [
     "diff",
+    "--no-ext-diff",
     "--quiet",
     "--relative",
     "--unified=0",


### PR DESCRIPTION
**Note**: I haven't been able to test this because I couldn't get yarn v3 to install a local package and ran out of time, but I checked that removing difft from my git config fixes the issue.

An external tool configured in git's diff.external setting can break
eslint-plugin-diff.

For example difft seems to always take over regular git diff output,
even in non interactive sessions. This results in eslint-plugin-diff not
being able to parse the diff output and exiting with no errors.

This change adds --no-ext-diff to the git diff commands, which overrides
the diff.external setting.
