### PR TITLE
Always run messages that have fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,12 @@ If `CI` is set and `ESLINT_PLUGIN_DIFF_COMMIT` is not set, the plugin attempts p
 
 When set, the plugin can refresh the initial diff snapshot once to avoid delayed diagnostics in editor workflows.
 
+### `ESLINT_PLUGIN_DIFF_INCLUDE_FIXES`
+
+When set to `true`, the plugin keeps lint messages with available fixes even
+when those messages are outside changed diff hunks. This can make `eslint --fix`
+apply file-wide changes in modified files.
+
 ## Recipes
 
 ### Local diff vs default base (`HEAD`)

--- a/README.md
+++ b/README.md
@@ -89,6 +89,10 @@ When set to `true`, the plugin keeps lint messages with available fixes even
 when those messages are outside changed diff hunks. This can make `eslint --fix`
 apply file-wide changes in modified files.
 
+```sh
+ESLINT_PLUGIN_DIFF_INCLUDE_FIXES=true npx eslint --fix .
+```
+
 ## Recipes
 
 ### Local diff vs default base (`HEAD`)

--- a/src/__fixtures__/postprocessArguments.ts
+++ b/src/__fixtures__/postprocessArguments.ts
@@ -32,6 +32,10 @@ const postprocessArguments: [
         column: 1,
         nodeType: "IfStatement",
         messageId: "missingCurlyAfterCondition",
+        fix: {
+          range: [0, 3],
+          text: ''
+        }
       },
     ],
   ],

--- a/src/__snapshots__/processors.test.ts.snap
+++ b/src/__snapshots__/processors.test.ts.snap
@@ -45,6 +45,13 @@ exports[`processors diff postprocess 1`] = `
   },
   {
     "column": 1,
+    "fix": {
+      "range": [
+        0,
+        3,
+      ],
+      "text": "",
+    },
     "line": 3,
     "message": "Expected { after 'if' condition.",
     "messageId": "missingCurlyAfterCondition",

--- a/src/processors-include-fixes.test.ts
+++ b/src/processors-include-fixes.test.ts
@@ -6,9 +6,9 @@ jest.mock("./git", () => ({
   hasCleanIndex: jest.fn(),
 }));
 
-import type * as git from "./git";
 import { staged as fixtureStaged } from "./__fixtures__/diff";
 import { postprocessArguments } from "./__fixtures__/postprocessArguments";
+import type * as git from "./git";
 
 const importGit = async (): Promise<typeof import("./git.js")> =>
   import("./git.js");

--- a/src/processors-include-fixes.test.ts
+++ b/src/processors-include-fixes.test.ts
@@ -1,0 +1,69 @@
+jest.mock("./git", () => ({
+  ...jest.requireActual<typeof git>("./git"),
+  getTrackedFileList: jest.fn(),
+  getDiffFileList: jest.fn(),
+  getDiffForFile: jest.fn(),
+  hasCleanIndex: jest.fn(),
+}));
+
+import type * as git from "./git";
+import { staged as fixtureStaged } from "./__fixtures__/diff";
+import { postprocessArguments } from "./__fixtures__/postprocessArguments";
+
+const importGit = async (): Promise<typeof import("./git.js")> =>
+  import("./git.js");
+const importProcessors = async (): Promise<typeof import("./processors.js")> =>
+  import("./processors.js");
+
+const OLD_ENV = process.env;
+const [, filename] = postprocessArguments;
+
+beforeEach(() => {
+  jest.resetModules();
+  jest.clearAllMocks();
+  process.env = { ...OLD_ENV };
+  delete process.env["ESLINT_PLUGIN_DIFF_INCLUDE_FIXES"];
+});
+
+afterAll(() => {
+  process.env = OLD_ENV;
+});
+
+describe("ESLINT_PLUGIN_DIFF_INCLUDE_FIXES", () => {
+  it("does not include fix messages outside changed ranges by default", async () => {
+    const [messages] = postprocessArguments;
+    const gitMocked: jest.MockedObjectDeep<typeof git> = jest.mocked(
+      await importGit(),
+    );
+    gitMocked.getDiffFileList.mockReturnValue([filename]);
+    gitMocked.getTrackedFileList.mockReturnValue([filename]);
+    gitMocked.getDiffForFile.mockReturnValue(fixtureStaged);
+    gitMocked.hasCleanIndex.mockReturnValue(true);
+
+    const { staged } = await importProcessors();
+    const result = staged.postprocess(messages, filename);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.line).toBe(2);
+  });
+
+  it("includes fix messages outside changed ranges when enabled", async () => {
+    const [messages] = postprocessArguments;
+    process.env["ESLINT_PLUGIN_DIFF_INCLUDE_FIXES"] = "true";
+
+    const gitMocked: jest.MockedObjectDeep<typeof git> = jest.mocked(
+      await importGit(),
+    );
+    gitMocked.getDiffFileList.mockReturnValue([filename]);
+    gitMocked.getTrackedFileList.mockReturnValue([filename]);
+    gitMocked.getDiffForFile.mockReturnValue(fixtureStaged);
+    gitMocked.hasCleanIndex.mockReturnValue(true);
+
+    const { staged } = await importProcessors();
+    const result = staged.postprocess(messages, filename);
+
+    expect(result).toHaveLength(2);
+    expect(result[1]?.line).toBe(3);
+    expect(result[1]?.fix).toBeDefined();
+  });
+});

--- a/src/processors.ts
+++ b/src/processors.ts
@@ -124,7 +124,12 @@ const getUnstagedChangesError = (filename: string): [Linter.LintMessage] => {
 };
 
 const getPostProcessor =
-  (trackedFileSet: Set<string>, staged: boolean, initialize?: () => void) =>
+  (
+    trackedFileSet: Set<string>,
+    staged: boolean,
+    includeFixes: boolean,
+    initialize?: () => void,
+  ) =>
   (
     messages: Linter.LintMessage[][],
     filename: string,
@@ -148,8 +153,12 @@ const getPostProcessor =
     const rangesForDiff = getRangesForDiff(getDiffForFile(filename, staged));
 
     return messages.flatMap((message) => {
-      const filteredMessage = message.filter(({ fatal, line }) => {
+      const filteredMessage = message.filter(({ fatal, line, fix }) => {
         if (fatal === true) {
+          return true;
+        }
+
+        if (includeFixes && fix !== undefined) {
           return true;
         }
 
@@ -172,12 +181,18 @@ type DiffProcessor = Linter.Processor &
 
 const getProcessors = (processorType: ProcessorType): DiffProcessor => {
   const staged = processorType === "staged";
+  const includeFixes = process.env["ESLINT_PLUGIN_DIFF_INCLUDE_FIXES"] === "true";
   const initialize = processorType === "ci" ? createCiInitializer() : undefined;
   const trackedFileSet = new Set(getTrackedFileList());
 
   return {
     preprocess: getPreProcessor(trackedFileSet, staged, initialize),
-    postprocess: getPostProcessor(trackedFileSet, staged, initialize),
+    postprocess: getPostProcessor(
+      trackedFileSet,
+      staged,
+      includeFixes,
+      initialize,
+    ),
     supportsAutofix: true,
   };
 };

--- a/src/processors.ts
+++ b/src/processors.ts
@@ -181,7 +181,8 @@ type DiffProcessor = Linter.Processor &
 
 const getProcessors = (processorType: ProcessorType): DiffProcessor => {
   const staged = processorType === "staged";
-  const includeFixes = process.env["ESLINT_PLUGIN_DIFF_INCLUDE_FIXES"] === "true";
+  const includeFixes =
+    process.env["ESLINT_PLUGIN_DIFF_INCLUDE_FIXES"] === "true";
   const initialize = processorType === "ci" ? createCiInitializer() : undefined;
   const trackedFileSet = new Set(getTrackedFileList());
 


### PR DESCRIPTION
Hi there,

Firstly, thanks for this great plugin, it's a huge help to incrementally enabling new lint rules on our code base 🥳 

There's one issue we ran into where on our pre commit hook we use [this plugin](https://github.com/lydell/eslint-plugin-simple-import-sort) to auto sort imports, however because the fixer affects lines of code that weren't actually changed the fixer never runs and our imports are no longer auto sorted.

The easiest way I could see to fix this is to always run rules that have auto fixes. I think it makes sense to always do this but maybe it should be an option or something? Happy to discuss this more!