### PR TITLE
Move getDiffFileList inside the processor

### DIFF
--- a/src/processors.ts
+++ b/src/processors.ts
@@ -28,8 +28,8 @@ if (process.env.CI !== undefined) {
  * This is increasingly useful the more files there are in the repository.
  */
 const getPreProcessor =
-  (diffFileList: string[], staged: boolean) =>
-  (text: string, filename: string) => {
+  (staged: boolean) => (text: string, filename: string) => {
+    const diffFileList = getDiffFileList(staged);
     let untrackedFileList = getUntrackedFileList(staged);
     const shouldRefresh =
       !diffFileList.includes(filename) && !untrackedFileList.includes(filename);
@@ -117,10 +117,9 @@ const getProcessors = (
   processorType: ProcessorType
 ): Required<Linter.Processor> => {
   const staged = processorType === "staged";
-  const diffFileList = getDiffFileList(staged);
 
   return {
-    preprocess: getPreProcessor(diffFileList, staged),
+    preprocess: getPreProcessor(staged),
     postprocess: getPostProcessor(staged),
     supportsAutofix: true,
   };


### PR DESCRIPTION
Duplicating context from #31 

By default, `diff/diff` pulls changes from both ahead and behind commits and runs ESLint on them. Most likely use case though, is that we we want to run ESLint only on changes introduced by ahead commits.

To work around the above issue `ESLINT_PLUGIN_DIFF_COMMIT` can be set to something like `base_branch...`, but this is not a valid syntax for `git diff --staged`, and because `getProcessors` function pulls `diffFileList` - it is run for all 3 processors during plugin init, regardless of desired processor, resulting in failure when staged processor is loaded.

This PR moves `diffFileList` call inside the processor, so it won't get invoked during plugin load, which should resolve the issue w/o changing anything else.