### PR TITLE
do not use origin... 

### DIFF
--- a/src/processors.ts
+++ b/src/processors.ts
@@ -13,10 +13,8 @@ import type { Range } from "./Range";
 if (process.env.CI !== undefined) {
   const branch = process.env.ESLINT_PLUGIN_DIFF_COMMIT ?? guessBranch();
   if (branch !== undefined) {
-    const branchWithoutOrigin = branch.replace(/^origin\//, "");
-    const branchWithOrigin = `origin/${branchWithoutOrigin}`;
-    fetchFromOrigin(branchWithoutOrigin);
-    process.env.ESLINT_PLUGIN_DIFF_COMMIT = branchWithOrigin;
+    fetchFromOrigin(branch);
+    process.env.ESLINT_PLUGIN_DIFF_COMMIT = branch;
   }
 }
 


### PR DESCRIPTION
Do not automagically add origin/ to the branch name.

If the user wants to user origin/ they can add it themselves.

This prevents:

fatal: ambiguous argument 'origin/my_branch': unknown revision or path not in the working tree.