### PR TITLE
Replace VSCODE_CLI -> VSCODE_PID

### DIFF
--- a/src/processors.ts
+++ b/src/processors.ts
@@ -37,7 +37,7 @@ const getPreProcessor =
       untrackedFileList = getUntrackedFileList(staged, true);
     }
     const shouldBeProcessed =
-      process.env.VSCODE_CLI !== undefined ||
+      process.env.VSCODE_PID !== undefined ||
       diffFileList.includes(filename) ||
       untrackedFileList.includes(filename);
 


### PR DESCRIPTION
## Description
`VSCODE_CLI` doesn't seem to exist anymore. Seems like it might've been removed in the last ~2 years? `VSCODE_PID` looks to be the thing set now when ESLint is ran inside VSCode (v1.83.1, at least)


## Test Plan
- enabled ESLint debugging in VSCode
- verified `process.env.VSCODE_PID` is set when the plugin is ran