### PR TITLE
Use git-diff-index plumbing instead of git-diff porcelain

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,16 @@ Only lint the changes you've staged for an upcoming commit.
 }
 ```
 
+#### `"plugin:diff/committed"`
+
+Only lint the changes you've committed, for running in a pre-push hook. You should set `ESLINT_PLUGIN_DIFF_COMMIT` in your pre-push hook for this to be useful.
+
+```json
+{
+  "extends": ["plugin:diff/committed"]
+}
+```
+
 ## CI Setup
 
 To lint all the changes of a pull-request, you only have to set

--- a/src/__snapshots__/index.test.ts.snap
+++ b/src/__snapshots__/index.test.ts.snap
@@ -15,6 +15,19 @@ exports[`plugin should match expected export 1`] = `
       "diff",
     ],
   },
+  "committed": {
+    "overrides": [
+      {
+        "files": [
+          "*",
+        ],
+        "processor": "diff/committed",
+      },
+    ],
+    "plugins": [
+      "diff",
+    ],
+  },
   "diff": {
     "overrides": [
       {
@@ -50,6 +63,11 @@ exports[`plugin should match expected export 2`] = `
     "postprocess": [Function],
     "preprocess": [Function],
     "supportsAutofix": true,
+  },
+  "committed": {
+    "postprocess": [Function],
+    "preprocess": [Function],
+    "supportsAutofix": false,
   },
   "diff": {
     "postprocess": [Function],

--- a/src/git.test.ts
+++ b/src/git.test.ts
@@ -51,7 +51,7 @@ describe("getDiffForFile", () => {
     mockedChildProcess.execFileSync.mockReturnValueOnce(hunks);
     process.env.ESLINT_PLUGIN_DIFF_COMMIT = "1234567";
 
-    const diffFromFile = getDiffForFile("./mockfile.js", true);
+    const diffFromFile = getDiffForFile("./mockfile.js", "staged");
 
     const expectedCommand = "git";
     const expectedArgs =
@@ -71,7 +71,7 @@ describe("getDiffForFile", () => {
     mockedChildProcess.execFileSync.mockReturnValueOnce(hunks);
     process.env.ESLINT_PLUGIN_DIFF_COMMIT = "1234567";
 
-    const diffFromFile = getDiffForFile("./mockfile.js", false);
+    const diffFromFile = getDiffForFile("./mockfile.js", "working");
 
     const expectedCommand = "git";
     const expectedArgs =
@@ -91,7 +91,7 @@ describe("getDiffForFile", () => {
     mockedChildProcess.execFileSync.mockReturnValueOnce(hunks);
     process.env.ESLINT_PLUGIN_DIFF_COMMIT = undefined;
 
-    const diffFromFile = getDiffForFile("./mockfile.js", false);
+    const diffFromFile = getDiffForFile("./mockfile.js", "working");
 
     const expectedCommand = "git";
     const expectedArgs =
@@ -131,7 +131,7 @@ describe("getDiffFileList", () => {
     jest.mock("child_process").resetAllMocks();
     mockedChildProcess.execFileSync.mockReturnValueOnce(diffFileList);
     expect(mockedChildProcess.execFileSync).toHaveBeenCalledTimes(0);
-    const fileListA = getDiffFileList(false);
+    const fileListA = getDiffFileList("working");
 
     expect(mockedChildProcess.execFileSync).toHaveBeenCalledTimes(1);
     expect(fileListA).toEqual(
@@ -145,12 +145,11 @@ describe("getUntrackedFileList", () => {
     jest.mock("child_process").resetAllMocks();
     mockedChildProcess.execFileSync.mockReturnValueOnce(diffFileList);
     expect(mockedChildProcess.execFileSync).toHaveBeenCalledTimes(0);
-    const fileListA = getUntrackedFileList(false);
+    const fileListA = getUntrackedFileList("working");
     expect(mockedChildProcess.execFileSync).toHaveBeenCalledTimes(1);
 
     mockedChildProcess.execFileSync.mockReturnValueOnce(diffFileList);
-    const staged = false;
-    const fileListB = getUntrackedFileList(staged);
+    const fileListB = getUntrackedFileList("working");
     // `getUntrackedFileList` uses a cache, so the number of calls to
     // `execFileSync` will not have increased.
     expect(mockedChildProcess.execFileSync).toHaveBeenCalledTimes(1);
@@ -162,7 +161,10 @@ describe("getUntrackedFileList", () => {
   });
 
   it("should not get a list when looking when using staged", () => {
-    const staged = true;
-    expect(getUntrackedFileList(staged)).toEqual([]);
+    expect(getUntrackedFileList("staged")).toEqual([]);
+  });
+
+  it("should not get a list when looking when using committed", () => {
+    expect(getUntrackedFileList("committed")).toEqual([]);
   });
 });

--- a/src/git.test.ts
+++ b/src/git.test.ts
@@ -55,7 +55,7 @@ describe("getDiffForFile", () => {
 
     const expectedCommand = "git";
     const expectedArgs =
-      "diff --diff-algorithm=histogram --diff-filter=ACM --find-renames=100% --no-ext-diff --relative --staged --unified=0 1234567";
+      "diff-index --diff-algorithm=histogram --diff-filter=ACM --find-renames=100% --no-ext-diff --relative --cached --unified=0 1234567";
 
     const lastCall = mockedChildProcess.execFileSync.mock.calls.at(-1);
     const [command, argsIncludingFile = []] = lastCall ?? [""];
@@ -75,7 +75,7 @@ describe("getDiffForFile", () => {
 
     const expectedCommand = "git";
     const expectedArgs =
-      "diff --diff-algorithm=histogram --diff-filter=ACM --find-renames=100% --no-ext-diff --relative --unified=0 1234567";
+      "diff-index --diff-algorithm=histogram --diff-filter=ACM --find-renames=100% --no-ext-diff --relative --unified=0 1234567";
 
     const lastCall = mockedChildProcess.execFileSync.mock.calls.at(-1);
     const [command, argsIncludingFile = []] = lastCall ?? [""];
@@ -95,7 +95,7 @@ describe("getDiffForFile", () => {
 
     const expectedCommand = "git";
     const expectedArgs =
-      "diff --diff-algorithm=histogram --diff-filter=ACM --find-renames=100% --no-ext-diff --relative --unified=0 HEAD";
+      "diff-index --diff-algorithm=histogram --diff-filter=ACM --find-renames=100% --no-ext-diff --relative --unified=0 HEAD";
 
     const lastCall = mockedChildProcess.execFileSync.mock.calls.at(-1);
     const [command, argsIncludingFile = []] = lastCall ?? [""];

--- a/src/git.test.ts
+++ b/src/git.test.ts
@@ -48,7 +48,7 @@ describe("getRangesForDiff", () => {
 
 describe("getDiffForFile", () => {
   it("should get the staged diff of a file", () => {
-    mockedChildProcess.execFileSync.mockReturnValueOnce(Buffer.from(hunks));
+    mockedChildProcess.execFileSync.mockReturnValueOnce(hunks);
     process.env.ESLINT_PLUGIN_DIFF_COMMIT = "1234567";
 
     const diffFromFile = getDiffForFile("./mockfile.js", true);
@@ -68,7 +68,7 @@ describe("getDiffForFile", () => {
   });
 
   it("should work when using staged = false", () => {
-    mockedChildProcess.execFileSync.mockReturnValueOnce(Buffer.from(hunks));
+    mockedChildProcess.execFileSync.mockReturnValueOnce(hunks);
     process.env.ESLINT_PLUGIN_DIFF_COMMIT = "1234567";
 
     const diffFromFile = getDiffForFile("./mockfile.js", false);
@@ -88,7 +88,7 @@ describe("getDiffForFile", () => {
   });
 
   it("should use HEAD when no commit was defined", () => {
-    mockedChildProcess.execFileSync.mockReturnValueOnce(Buffer.from(hunks));
+    mockedChildProcess.execFileSync.mockReturnValueOnce(hunks);
     process.env.ESLINT_PLUGIN_DIFF_COMMIT = undefined;
 
     const diffFromFile = getDiffForFile("./mockfile.js", false);
@@ -120,7 +120,7 @@ describe("hasCleanIndex", () => {
 
   it("returns true otherwise", () => {
     jest.mock("child_process").resetAllMocks();
-    mockedChildProcess.execFileSync.mockReturnValue(Buffer.from(""));
+    mockedChildProcess.execFileSync.mockReturnValue("");
     expect(hasCleanIndex("")).toEqual(true);
     expect(mockedChildProcess.execFileSync).toHaveBeenCalled();
   });
@@ -129,9 +129,7 @@ describe("hasCleanIndex", () => {
 describe("getDiffFileList", () => {
   it("should get the list of staged files", () => {
     jest.mock("child_process").resetAllMocks();
-    mockedChildProcess.execFileSync.mockReturnValueOnce(
-      Buffer.from(diffFileList)
-    );
+    mockedChildProcess.execFileSync.mockReturnValueOnce(diffFileList);
     expect(mockedChildProcess.execFileSync).toHaveBeenCalledTimes(0);
     const fileListA = getDiffFileList(false);
 
@@ -145,16 +143,12 @@ describe("getDiffFileList", () => {
 describe("getUntrackedFileList", () => {
   it("should get the list of untracked files", () => {
     jest.mock("child_process").resetAllMocks();
-    mockedChildProcess.execFileSync.mockReturnValueOnce(
-      Buffer.from(diffFileList)
-    );
+    mockedChildProcess.execFileSync.mockReturnValueOnce(diffFileList);
     expect(mockedChildProcess.execFileSync).toHaveBeenCalledTimes(0);
     const fileListA = getUntrackedFileList(false);
     expect(mockedChildProcess.execFileSync).toHaveBeenCalledTimes(1);
 
-    mockedChildProcess.execFileSync.mockReturnValueOnce(
-      Buffer.from(diffFileList)
-    );
+    mockedChildProcess.execFileSync.mockReturnValueOnce(diffFileList);
     const staged = false;
     const fileListB = getUntrackedFileList(staged);
     // `getUntrackedFileList` uses a cache, so the number of calls to

--- a/src/git.ts
+++ b/src/git.ts
@@ -53,7 +53,7 @@ const getDiffFileList = (staged: boolean): string[] => {
 
 const hasCleanIndex = (filePath: string): boolean => {
   const args = [
-    "diff",
+    "diff-files",
     "--no-ext-diff",
     "--quiet",
     "--relative",

--- a/src/git.ts
+++ b/src/git.ts
@@ -7,13 +7,13 @@ const OPTIONS = { maxBuffer: 1024 * 1024 * 100 };
 
 const getDiffForFile = (filePath: string, staged: boolean): string => {
   const args = [
-    "diff",
+    "diff-index",
     "--diff-algorithm=histogram",
     "--diff-filter=ACM",
     "--find-renames=100%",
     "--no-ext-diff",
     "--relative",
-    staged && "--staged",
+    staged && "--cached",
     "--unified=0",
     process.env.ESLINT_PLUGIN_DIFF_COMMIT ?? "HEAD",
     "--",
@@ -28,14 +28,14 @@ const getDiffForFile = (filePath: string, staged: boolean): string => {
 
 const getDiffFileList = (staged: boolean): string[] => {
   const args = [
-    "diff",
+    "diff-index",
     "--diff-algorithm=histogram",
     "--diff-filter=ACM",
     "--find-renames=100%",
     "--name-only",
     "--no-ext-diff",
     "--relative",
-    staged && "--staged",
+    staged && "--cached",
     process.env.ESLINT_PLUGIN_DIFF_COMMIT ?? "HEAD",
     "--",
   ].reduce<string[]>(

--- a/src/git.ts
+++ b/src/git.ts
@@ -68,6 +68,27 @@ const hasCleanIndex = (filePath: string): boolean => {
   return true;
 };
 
+const hasCleanTree = (filePath: string): boolean => {
+  const args = [
+    "diff-index",
+    "--no-ext-diff",
+    "--quiet",
+    "--relative",
+    "--unified=0",
+    "HEAD",
+    "--",
+    resolve(filePath),
+  ];
+
+  try {
+    child_process.execFileSync(COMMAND, args, OPTIONS);
+  } catch (err: unknown) {
+    return false;
+  }
+
+  return true;
+};
+
 const fetchFromOrigin = (branch: string) => {
   const args = ["fetch", "--quiet", "origin", branch];
 
@@ -151,6 +172,13 @@ const getRangesForDiff = (diff: string): Range[] =>
     return [...ranges, range];
   }, []);
 
+const readFileFromGit = (filePath: string) => {
+  const getBlob = ["ls-tree", "--object-only", "HEAD", resolve(filePath)];
+  const blob = child_process.execFileSync(COMMAND, getBlob, OPTIONS).trim();
+  const catFile = ["cat-file", "blob", blob];
+  return child_process.execFileSync(COMMAND, catFile, OPTIONS);
+};
+
 export {
   fetchFromOrigin,
   getDiffFileList,
@@ -158,4 +186,6 @@ export {
   getRangesForDiff,
   getUntrackedFileList,
   hasCleanIndex,
+  hasCleanTree,
+  readFileFromGit,
 };

--- a/src/git.ts
+++ b/src/git.ts
@@ -18,10 +18,7 @@ const getDiffForFile = (filePath: string, staged: boolean): string => {
     process.env.ESLINT_PLUGIN_DIFF_COMMIT ?? "HEAD",
     "--",
     resolve(filePath),
-  ].reduce<string[]>(
-    (acc, cur) => (typeof cur === "string" ? [...acc, cur] : acc),
-    []
-  );
+  ].filter((cur): cur is string => typeof cur === "string");
 
   return child_process.execFileSync(COMMAND, args, OPTIONS).toString();
 };
@@ -38,10 +35,7 @@ const getDiffFileList = (staged: boolean): string[] => {
     staged && "--cached",
     process.env.ESLINT_PLUGIN_DIFF_COMMIT ?? "HEAD",
     "--",
-  ].reduce<string[]>(
-    (acc, cur) => (typeof cur === "string" ? [...acc, cur] : acc),
-    []
-  );
+  ].filter((cur): cur is string => typeof cur === "string");
 
   return child_process
     .execFileSync(COMMAND, args, OPTIONS)

--- a/src/git.ts
+++ b/src/git.ts
@@ -36,6 +36,7 @@ const getDiffFileList = (diffType: DiffType): string[] => {
     "--no-ext-diff",
     "--relative",
     diffType === "staged" && "--cached",
+    diffType === "committed" && "-r",
     process.env.ESLINT_PLUGIN_DIFF_COMMIT ?? "HEAD",
     diffType === "committed" && "HEAD",
     "--",

--- a/src/git.ts
+++ b/src/git.ts
@@ -3,7 +3,7 @@ import { resolve } from "path";
 import { Range } from "./Range";
 
 const COMMAND = "git";
-const OPTIONS = { maxBuffer: 1024 * 1024 * 100 };
+const OPTIONS = { encoding: "utf8" as const, maxBuffer: 1024 * 1024 * 100 };
 
 const getDiffForFile = (filePath: string, staged: boolean): string => {
   const args = [
@@ -20,7 +20,7 @@ const getDiffForFile = (filePath: string, staged: boolean): string => {
     resolve(filePath),
   ].filter((cur): cur is string => typeof cur === "string");
 
-  return child_process.execFileSync(COMMAND, args, OPTIONS).toString();
+  return child_process.execFileSync(COMMAND, args, OPTIONS);
 };
 
 const getDiffFileList = (staged: boolean): string[] => {
@@ -39,7 +39,6 @@ const getDiffFileList = (staged: boolean): string[] => {
 
   return child_process
     .execFileSync(COMMAND, args, OPTIONS)
-    .toString()
     .trim()
     .split("\n")
     .map((filePath) => resolve(filePath));
@@ -85,7 +84,6 @@ const getUntrackedFileList = (
 
     untrackedFileListCache = child_process
       .execFileSync(COMMAND, args, OPTIONS)
-      .toString()
       .trim()
       .split("\n")
       .map((filePath) => resolve(filePath));

--- a/src/index-ci.test.ts
+++ b/src/index-ci.test.ts
@@ -4,9 +4,7 @@ import * as child_process from "child_process";
 
 jest.mock("child_process");
 const mockedChildProcess = jest.mocked(child_process, { shallow: true });
-mockedChildProcess.execFileSync.mockReturnValue(
-  Buffer.from("line1\nline2\nline3")
-);
+mockedChildProcess.execFileSync.mockReturnValue("line1\nline2\nline3");
 
 import "./index";
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -3,9 +3,7 @@ import * as child_process from "child_process";
 
 jest.mock("child_process");
 const mockedChildProcess = jest.mocked(child_process, { shallow: true });
-mockedChildProcess.execFileSync.mockReturnValue(
-  Buffer.from("line1\nline2\nline3")
-);
+mockedChildProcess.execFileSync.mockReturnValue("line1\nline2\nline3");
 
 import { configs, processors } from "./index";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,14 +5,17 @@ import {
   diffConfig,
   staged,
   stagedConfig,
+  committed,
+  committedConfig,
 } from "./processors";
 
 const configs = {
   ci: ciConfig,
   diff: diffConfig,
   staged: stagedConfig,
+  committed: committedConfig,
 };
-const processors = { ci, diff, staged };
+const processors = { ci, diff, staged, committed };
 
 module.exports = { configs, processors };
 

--- a/src/processors.ts
+++ b/src/processors.ts
@@ -8,6 +8,8 @@ import {
   getRangesForDiff,
   getUntrackedFileList,
   hasCleanIndex,
+  hasCleanTree,
+  readFileFromGit,
 } from "./git";
 import type { Range } from "./Range";
 
@@ -43,6 +45,14 @@ const getPreProcessor =
       process.env.VSCODE_PID !== undefined ||
       diffFileList.includes(filename) ||
       untrackedFileList.includes(filename);
+
+    if (
+      diffType === "committed" &&
+      shouldBeProcessed &&
+      !hasCleanTree(filename)
+    ) {
+      return [readFileFromGit(filename)];
+    }
 
     return shouldBeProcessed ? [text] : [];
   };

--- a/src/processors.ts
+++ b/src/processors.ts
@@ -145,6 +145,7 @@ const getProcessors = (
 const ci = process.env.CI !== undefined ? getProcessors("ci") : {};
 const diff = getProcessors("diff");
 const staged = getProcessors("staged");
+const committed = getProcessors("committed");
 
 const diffConfig: Linter.BaseConfig = {
   plugins: ["diff"],
@@ -179,6 +180,16 @@ const stagedConfig: Linter.BaseConfig = {
   ],
 };
 
+const committedConfig: Linter.BaseConfig = {
+  plugins: ["diff"],
+  overrides: [
+    {
+      files: ["*"],
+      processor: "diff/committed",
+    },
+  ],
+};
+
 export {
   ci,
   ciConfig,
@@ -186,5 +197,7 @@ export {
   diffConfig,
   staged,
   stagedConfig,
+  committed,
+  committedConfig,
   getUnstagedChangesError,
 };

--- a/src/processors.ts
+++ b/src/processors.ts
@@ -33,7 +33,9 @@ const getPreProcessor =
   (text: string, filename: string) => {
     let untrackedFileList = getUntrackedFileList(diffType);
     const shouldRefresh =
-      !diffFileList.includes(filename) && !untrackedFileList.includes(filename);
+      diffType === "working" &&
+      !diffFileList.includes(filename) &&
+      !untrackedFileList.includes(filename);
     if (shouldRefresh) {
       untrackedFileList = getUntrackedFileList(diffType, true);
     }


### PR DESCRIPTION
### Background

Because of various factors, my team prefers to run lints in a pre-push hook. While the `diff` or `staged` config could work, an ideal solution is to only lint the changes that are actually being pushed to the remote.

### Solution

This PR adds a new config and processor, "committed" that allows linting only changes that have already been committed. It requires that the `ESLINT_PLUGIN_DIFF_COMMIT` environment variable is set, otherwise there will be nothing in the diff to lint.

Additionally, if a file has been changed on disk compared to the `HEAD` commit, the preprocessor will fetch the commmitted contents from git and lint that instead -- this preprocessor is why the `autofix` is disabled. This technique could be used in an alternative version of the `staged` linter which would lint the file as it has been committed rather than throwing the "unstaged changes" error.

### Other notes

I've done a bit of refactoring to my tastes, although those can be omitted. They're available in separate branches: 1st, [swapping out git porcelain commands for git plumbing commands](https://github.com/paleite/eslint-plugin-diff/compare/main...forivall:eslint-plugin-diff:plumbing) (more stable interface), and [2nd, some miscellaneous changes](https://github.com/forivall/eslint-plugin-diff/compare/26e3989ce527023e5dc280b03bd29561b38df476...forivall:eslint-plugin-diff:refactors) (use filter instead of reduce, using string encoding in `execFileSync` instead of `.toString()`, and changing `getPreProcessor` so that it fetches the diff file list when linting is run, instead of when the file is loaded, allowing for other plugins to change `process.env.ESLINT_PLUGIN_DIFF_COMMIT` if they need to, before eslint-plugin-diff.

I would like to expand this into an independent CLI tool to allow ideal pre-push linting, but hopefully you consider merging my changes! If not, I'm happy to maintain a friendly fork.