### PR TITLE
Keep tracked files instead of refreshing list of untracked files

### DIFF
--- a/src/git.test.ts
+++ b/src/git.test.ts
@@ -1,5 +1,5 @@
-import * as child_process from "child_process";
-import path from "path";
+import * as child_process from "node:child_process";
+import path from "node:path";
 
 import {
   diffFileList,
@@ -11,7 +11,7 @@ import {
   getDiffFileList,
   getDiffForFile,
   getRangesForDiff,
-  getUntrackedFileList,
+  getTrackedFileList,
   hasCleanIndex,
 } from "./git";
 
@@ -114,7 +114,7 @@ describe("hasCleanIndex", () => {
   it("returns false instead of throwing", () => {
     jest.mock("child_process").resetAllMocks();
     mockedChildProcess.execFileSync.mockImplementationOnce(() => {
-      throw Error("mocked error");
+      throw new Error("mocked error");
     });
     expect(hasCleanIndex("")).toEqual(false);
     expect(mockedChildProcess.execFileSync).toHaveBeenCalled();
@@ -174,35 +174,34 @@ describe("getDiffFileList", () => {
     expect(args).toContain("--staged");
     expect(args).toContain("1234567");
   });
+
+  it("returns an empty list when git diff has no output", () => {
+    jest.mock("child_process").resetAllMocks();
+    mockedChildProcess.execFileSync.mockReturnValueOnce(Buffer.from(""));
+
+    expect(getDiffFileList(false)).toEqual([]);
+  });
 });
 
-describe("getUntrackedFileList", () => {
+describe("getTrackedFileList", () => {
   it("should get the list of untracked files", () => {
     jest.mock("child_process").resetAllMocks();
     mockedChildProcess.execFileSync.mockReturnValueOnce(
       Buffer.from(diffFileList),
     );
     expect(mockedChildProcess.execFileSync).toHaveBeenCalledTimes(0);
-    const fileListA = getUntrackedFileList(false);
-    expect(mockedChildProcess.execFileSync).toHaveBeenCalledTimes(1);
-
-    mockedChildProcess.execFileSync.mockReturnValueOnce(
-      Buffer.from(diffFileList),
-    );
-    const staged = false;
-    const fileListB = getUntrackedFileList(staged);
-    // `getUntrackedFileList` uses a cache, so the number of calls to
-    // `execFileSync` will not have increased.
+    const fileListA = getTrackedFileList();
     expect(mockedChildProcess.execFileSync).toHaveBeenCalledTimes(1);
 
     expect(fileListA).toEqual(
       ["file1", "file2", "file3"].map((p) => path.resolve(p)),
     );
-    expect(fileListA).toEqual(fileListB);
   });
 
-  it("should not get a list when looking when using staged", () => {
-    const staged = true;
-    expect(getUntrackedFileList(staged)).toEqual([]);
+  it("returns an empty list when git ls-files has no output", () => {
+    jest.mock("child_process").resetAllMocks();
+    mockedChildProcess.execFileSync.mockReturnValueOnce(Buffer.from(""));
+
+    expect(getTrackedFileList()).toEqual([]);
   });
 });

--- a/src/git.ts
+++ b/src/git.ts
@@ -45,6 +45,7 @@ const getDiffFileList = (staged: boolean): string[] => {
     .toString()
     .trim()
     .split("\n")
+    .filter((filePath) => filePath.length > 0)
     .map((filePath) => resolve(filePath));
 };
 
@@ -74,27 +75,16 @@ const fetchFromOrigin = (branch: string) => {
   child_process.execFileSync(COMMAND, args, OPTIONS);
 };
 
-let untrackedFileListCache: string[] | undefined;
-const getUntrackedFileList = (
-  staged: boolean,
-  shouldRefresh = false,
-): string[] => {
-  if (staged) {
-    return [];
-  }
+const getTrackedFileList = (): string[] => {
+  const args = ["ls-files"];
 
-  if (untrackedFileListCache === undefined || shouldRefresh) {
-    const args = ["ls-files", "--exclude-standard", "--others"];
-
-    untrackedFileListCache = child_process
-      .execFileSync(COMMAND, args, OPTIONS)
-      .toString()
-      .trim()
-      .split("\n")
-      .map((filePath) => resolve(filePath));
-  }
-
-  return untrackedFileListCache;
+  return child_process
+    .execFileSync(COMMAND, args, OPTIONS)
+    .toString()
+    .trim()
+    .split("\n")
+    .filter((filePath) => filePath.length > 0)
+    .map((filePath) => resolve(filePath));
 };
 
 const isHunkHeader = (input: string) => {
@@ -156,6 +146,6 @@ export {
   getDiffFileList,
   getDiffForFile,
   getRangesForDiff,
-  getUntrackedFileList,
+  getTrackedFileList,
   hasCleanIndex,
 };

--- a/src/processors-ci-init.test.ts
+++ b/src/processors-ci-init.test.ts
@@ -3,7 +3,7 @@ jest.mock("./git", () => ({
   fetchFromOrigin: jest.fn(),
   getDiffFileList: jest.fn().mockReturnValue([]),
   getDiffForFile: jest.fn().mockReturnValue(""),
-  getUntrackedFileList: jest.fn().mockReturnValue([]),
+  getTrackedFileList: jest.fn().mockReturnValue([]),
   hasCleanIndex: jest.fn().mockReturnValue(true),
 }));
 
@@ -86,5 +86,22 @@ describe("CI initialization", () => {
 
     expect(gitMocked.fetchFromOrigin).not.toHaveBeenCalled();
     expect(process.env["ESLINT_PLUGIN_DIFF_COMMIT"]).toBe("abc123");
+  });
+
+  it("preserves namespace-qualified refs and skips origin fetch", async () => {
+    process.env["CI"] = "true";
+    process.env["GITHUB_BASE_REF"] = "main";
+    process.env["ESLINT_PLUGIN_DIFF_COMMIT"] = "refs/remotes/origin/main";
+
+    const gitMocked: jest.MockedObjectDeep<typeof git> = jest.mocked(
+      await importGit(),
+    );
+    const { ci } = await importProcessors();
+    ci.preprocess("/** Some source code */", "file.ts");
+
+    expect(gitMocked.fetchFromOrigin).not.toHaveBeenCalled();
+    expect(process.env["ESLINT_PLUGIN_DIFF_COMMIT"]).toBe(
+      "refs/remotes/origin/main",
+    );
   });
 });

--- a/src/processors-no-ci.test.ts
+++ b/src/processors-no-ci.test.ts
@@ -19,7 +19,7 @@ describe("processors without CI", () => {
     jest.doMock("./git", () => ({
       ...jest.requireActual<typeof import("./git.js")>("./git"),
       getDiffFileList: jest.fn(() => []),
-      getUntrackedFileList: jest.fn(() => []),
+      getTrackedFileList: jest.fn(() => []),
       getDiffForFile: jest.fn(() => ""),
       hasCleanIndex: jest.fn(() => true),
     }));
@@ -48,5 +48,3 @@ describe("processors without CI", () => {
     });
   });
 });
-
-export {};

--- a/src/processors-vscode.test.ts
+++ b/src/processors-vscode.test.ts
@@ -1,10 +1,12 @@
 jest.mock("./git", () => ({
   ...jest.requireActual<typeof git>("./git"),
-  getUntrackedFileList: jest.fn(),
+  getTrackedFileList: jest.fn(),
   getDiffFileList: jest.fn(),
   getDiffForFile: jest.fn(),
   hasCleanIndex: jest.fn(),
 }));
+
+import type { Linter } from "eslint";
 
 import type * as git from "./git";
 const importGit = async (): Promise<typeof import("./git.js")> =>
@@ -38,7 +40,7 @@ describe("VS Code preprocess", () => {
       .mockReturnValue([filename])
       .mockReturnValueOnce([])
       .mockReturnValueOnce([filename]);
-    gitMocked.getUntrackedFileList.mockReturnValue([]);
+    gitMocked.getTrackedFileList.mockReturnValue([filename]);
 
     process.env["VSCODE_PID"] = "1234";
     const { diff } = await importProcessors();
@@ -46,5 +48,39 @@ describe("VS Code preprocess", () => {
 
     expect(diff.preprocess(sourceCode, filename)).toEqual([sourceCode]);
     expect(gitMocked.getDiffFileList.mock.calls.length).toBe(2);
+  });
+
+  it("keeps reporting diagnostics when a file becomes tracked mid-session", async () => {
+    const filename = "/tmp/new-file.ts";
+    const sourceCode = "/** Some source code */";
+    const messages: Linter.LintMessage[][] = [
+      [
+        {
+          ruleId: "mock",
+          severity: 1,
+          message: "mock msg",
+          line: 1,
+          column: 1,
+        },
+      ],
+    ];
+    const gitMocked: jest.MockedObjectDeep<typeof git> = jest.mocked(
+      await importGit(),
+    );
+
+    // Simulate processor startup before file is tracked.
+    gitMocked.getTrackedFileList.mockReturnValue([]);
+    gitMocked.getDiffFileList
+      .mockReturnValue([filename])
+      .mockReturnValueOnce([])
+      .mockReturnValueOnce([filename]);
+    gitMocked.getDiffForFile.mockReturnValue("");
+
+    process.env["VSCODE_PID"] = "1234";
+    const { diff } = await importProcessors();
+
+    expect(diff.preprocess(sourceCode, filename)).toEqual([sourceCode]);
+    expect(diff.postprocess(messages, filename)).toEqual(messages.flat());
+    expect(gitMocked.getDiffForFile).not.toHaveBeenCalled();
   });
 });

--- a/src/processors.test.ts
+++ b/src/processors.test.ts
@@ -1,6 +1,6 @@
 jest.mock("./git", () => ({
   ...jest.requireActual<typeof git>("./git"),
-  getUntrackedFileList: jest.fn(),
+  getTrackedFileList: jest.fn(),
   getDiffFileList: jest.fn(),
   getDiffForFile: jest.fn(),
   hasCleanIndex: jest.fn(),
@@ -19,10 +19,15 @@ const importProcessors = async (): Promise<typeof import("./processors.js")> =>
 
 const [messages, filename] = postprocessArguments;
 const untrackedFilename = "an-untracked-file.js";
+const trackedUnchangedFilename = "tracked-unchanged-file.js";
 
 const gitMocked: jest.MockedObjectDeep<typeof git> = jest.mocked(git);
 gitMocked.getDiffFileList.mockReturnValue([filename]);
-gitMocked.getUntrackedFileList.mockReturnValue([untrackedFilename]);
+gitMocked.getTrackedFileList.mockReturnValue([
+  filename,
+  "file-with-dirty-index.js",
+  trackedUnchangedFilename,
+]);
 
 describe("processors", () => {
   it("preprocess (diff and staged)", async () => {
@@ -38,18 +43,22 @@ describe("processors", () => {
     ]);
   });
 
-  it("preprocess refreshes untracked files when filename is unknown", async () => {
+  it("preprocess does not repeatedly refresh unknown files", async () => {
     const sourceCode = "/** Some source code */";
-    const unknownFilename = "unknown-file.ts";
-    gitMocked.getUntrackedFileList
-      .mockReturnValueOnce([])
-      .mockReturnValueOnce([])
-      .mockReturnValueOnce([]);
+    const unchangedTrackedFilename = trackedUnchangedFilename;
 
     const { diff: diffProcessors } = await importProcessors();
+    const trackedCallsBefore = gitMocked.getTrackedFileList.mock.calls.length;
 
-    expect(diffProcessors.preprocess(sourceCode, unknownFilename)).toEqual([]);
-    expect(gitMocked.getUntrackedFileList).toHaveBeenCalledWith(false, true);
+    expect(
+      diffProcessors.preprocess(sourceCode, unchangedTrackedFilename),
+    ).toEqual([]);
+    expect(
+      diffProcessors.preprocess(sourceCode, unchangedTrackedFilename),
+    ).toEqual([]);
+    expect(gitMocked.getTrackedFileList.mock.calls.length).toBe(
+      trackedCallsBefore,
+    );
   });
 
   it("diff postprocess", async () => {
@@ -128,7 +137,7 @@ describe("processors", () => {
     );
   });
 
-  it("composeProcessor skips base preprocess when diff excludes file", async () => {
+  it("composeProcessor runs base preprocess for unknown files", async () => {
     const basePreprocess = jest.fn((text: string) => [text]);
     const baseProcessor: Linter.Processor = {
       preprocess: basePreprocess,
@@ -137,15 +146,27 @@ describe("processors", () => {
       supportsAutofix: true,
     };
     const unknownFilename = "unknown-file.ts";
-    gitMocked.getUntrackedFileList
-      .mockReturnValueOnce([])
-      .mockReturnValueOnce([])
-      .mockReturnValueOnce([]);
 
     const { composeProcessor } = await importProcessors();
     const composed = composeProcessor(baseProcessor, "diff");
 
-    expect(composed.preprocess("text", unknownFilename)).toEqual([]);
+    expect(composed.preprocess("text", unknownFilename)).toEqual(["text"]);
+    expect(basePreprocess).toHaveBeenCalledTimes(1);
+  });
+
+  it("composeProcessor skips base preprocess for unchanged tracked files", async () => {
+    const basePreprocess = jest.fn((text: string) => [text]);
+    const baseProcessor: Linter.Processor = {
+      preprocess: basePreprocess,
+      postprocess: (processorMessages: Linter.LintMessage[][]) =>
+        processorMessages.flat(),
+      supportsAutofix: true,
+    };
+
+    const { composeProcessor } = await importProcessors();
+    const composed = composeProcessor(baseProcessor, "diff");
+
+    expect(composed.preprocess("text", trackedUnchangedFilename)).toEqual([]);
     expect(basePreprocess).not.toHaveBeenCalled();
   });
 

--- a/src/processors.ts
+++ b/src/processors.ts
@@ -6,7 +6,7 @@ import {
   getDiffFileList,
   getDiffForFile,
   getRangesForDiff,
-  getUntrackedFileList,
+  getTrackedFileList,
   hasCleanIndex,
 } from "./git";
 import type { Range } from "./Range";
@@ -56,6 +56,7 @@ const createCiInitializer = (): (() => void) => {
  * This is increasingly useful the more files there are in the repository.
  */
 const getPreProcessor = (
+  trackedFileSet: Set<string>,
   staged: boolean,
   initialize?: () => void,
 ): DiffProcessor["preprocess"] => {
@@ -84,22 +85,15 @@ const getPreProcessor = (
     if (process.env["VSCODE_PID"] !== undefined && !isInDiffFileList) {
       // Editors can invoke ESLint before our initial diff snapshot includes the
       // latest edit. Refresh once to avoid "second edit" diagnostics.
+      // TODO: This can refresh repeatedly for files still outside the diff set.
+      // Either enforce a one-time refresh or update the comment/docs.
       refreshDiffFileList();
-    }
-
-    let untrackedFileList = getUntrackedFileList(staged);
-    let untrackedFileSet = new Set(untrackedFileList);
-    const shouldRefresh =
-      !diffFileSetCache.has(filename) && !untrackedFileSet.has(filename);
-    if (shouldRefresh) {
-      untrackedFileList = getUntrackedFileList(staged, true);
-      untrackedFileSet = new Set(untrackedFileList);
     }
 
     const shouldBeProcessed =
       process.env["VSCODE_PID"] !== undefined ||
       diffFileSetCache.has(filename) ||
-      untrackedFileSet.has(filename);
+      !trackedFileSet.has(filename);
 
     return shouldBeProcessed ? [text] : [];
   };
@@ -130,7 +124,7 @@ const getUnstagedChangesError = (filename: string): [Linter.LintMessage] => {
 };
 
 const getPostProcessor =
-  (staged: boolean, initialize?: () => void) =>
+  (trackedFileSet: Set<string>, staged: boolean, initialize?: () => void) =>
   (
     messages: Linter.LintMessage[][],
     filename: string,
@@ -141,8 +135,7 @@ const getPostProcessor =
       // No need to filter, just return
       return [];
     }
-    const untrackedFileSet = new Set(getUntrackedFileList(staged));
-    if (untrackedFileSet.has(filename)) {
+    if (!trackedFileSet.has(filename)) {
       // We don't need to filter the messages of untracked files because they
       // would all be kept anyway, so we return them as-is.
       return messages.flat();
@@ -180,10 +173,11 @@ type DiffProcessor = Linter.Processor &
 const getProcessors = (processorType: ProcessorType): DiffProcessor => {
   const staged = processorType === "staged";
   const initialize = processorType === "ci" ? createCiInitializer() : undefined;
+  const trackedFileSet = new Set(getTrackedFileList());
 
   return {
-    preprocess: getPreProcessor(staged, initialize),
-    postprocess: getPostProcessor(staged, initialize),
+    preprocess: getPreProcessor(trackedFileSet, staged, initialize),
+    postprocess: getPostProcessor(trackedFileSet, staged, initialize),
     supportsAutofix: true,
   };
 };


### PR DESCRIPTION
https://github.com/paleite/eslint-plugin-diff/pull/27 introduced a massive performance regression with the recommended `diff/diff` setup. It effectively refreshes the list of untracked files for every unchanged file in the project.

Instead of constantly refreshing the tracked file list, it's better to get the list of tracked files once and we can simply check that a file is not in the list.