### PR TITLE
Fix handling of explicit references to baseline commit

### DIFF
--- a/src/processors.ts
+++ b/src/processors.ts
@@ -11,12 +11,21 @@ import {
 import type { Range } from "./Range";
 
 if (process.env.CI !== undefined) {
-  const branch = process.env.ESLINT_PLUGIN_DIFF_COMMIT ?? guessBranch();
-  if (branch !== undefined) {
-    const branchWithoutOrigin = branch.replace(/^origin\//, "");
-    const branchWithOrigin = `origin/${branchWithoutOrigin}`;
-    fetchFromOrigin(branchWithoutOrigin);
-    process.env.ESLINT_PLUGIN_DIFF_COMMIT = branchWithOrigin;
+  const ref = process.env.ESLINT_PLUGIN_DIFF_COMMIT ?? guessBranch();
+  if (ref !== undefined) {
+    if (ref.match(/^[a-f0-9]{40}$/i)) {
+      // Commit hash
+      process.env.ESLINT_PLUGIN_DIFF_COMMIT = ref;
+    } else if (ref.match(/^refs\//i)) {
+      // This is a namespace-qualified ref - take it as-is
+      process.env.ESLINT_PLUGIN_DIFF_COMMIT = ref;
+    } else {
+      // Assume that the upstream is named 'origin', and force that prefix
+      const branchWithoutOrigin = ref.replace(/^origin\//, "");
+      const branchWithOrigin = `origin/${branchWithoutOrigin}`;
+      fetchFromOrigin(branchWithoutOrigin);
+      process.env.ESLINT_PLUGIN_DIFF_COMMIT = branchWithOrigin;
+    }
   }
 }
 


### PR DESCRIPTION
In cases where ESLINT_PLUGIN_DIFF_COMMIT is a commit hash, it would get prefixed with "origin/" to generate a string that does not resolve as a git ref. A similar operation would happen with a namespace-qualified ref - `refs/heads/origin/main` -> `origin/refs/heads/main` also yields a string that doesn't function as a ref.

This changes to detect cases where the provided ref is more explicit, and disables the `origin/` prefixing in those cases.