### PR TITLE
Fix env variable in CI detection

### DIFF
--- a/src/ci.test.ts
+++ b/src/ci.test.ts
@@ -19,16 +19,16 @@ beforeEach(() => {
 });
 
 describe("guessBranch", () => {
-  it("ensure the branch is guessed if ESLINT_PLUGIN_COMMIT is not already set", async () => {
-    delete process.env.ESLINT_PLUGIN_COMMIT;
+  it("ensure the branch is guessed if ESLINT_PLUGIN_DIFF_COMMIT is not already set", async () => {
+    delete process.env.ESLINT_PLUGIN_DIFF_COMMIT;
     const { guessBranch } = await import("./ci");
-    expect(() => guessBranch()).not.toThrowError(/ESLINT_PLUGIN_COMMIT/u);
+    expect(() => guessBranch()).not.toThrowError(/ESLINT_PLUGIN_DIFF_COMMIT/u);
   });
 
-  it("ensure the branch is not guessed if ESLINT_PLUGIN_COMMIT is already set", async () => {
-    process.env.ESLINT_PLUGIN_COMMIT = "origin/main";
+  it("ensure the branch is not guessed if ESLINT_PLUGIN_DIFF_COMMIT is already set", async () => {
+    process.env.ESLINT_PLUGIN_DIFF_COMMIT = "origin/main";
     const { guessBranch } = await import("./ci");
-    expect(() => guessBranch()).toThrowError(/ESLINT_PLUGIN_COMMIT/u);
+    expect(() => guessBranch()).toThrowError(/ESLINT_PLUGIN_DIFF_COMMIT/u);
   });
 
   it("fails when too many providers were found as candidates", async () => {

--- a/src/ci.ts
+++ b/src/ci.ts
@@ -92,8 +92,8 @@ const guessProviders = () =>
   );
 
 const guessBranch = (): string | undefined => {
-  if ((process.env.ESLINT_PLUGIN_COMMIT ?? "").length > 0) {
-    throw Error("ESLINT_PLUGIN_COMMIT already set");
+  if ((process.env.ESLINT_PLUGIN_DIFF_COMMIT ?? "").length > 0) {
+    throw Error("ESLINT_PLUGIN_DIFF_COMMIT already set");
   }
 
   const guessedProviders = guessProviders();
@@ -103,7 +103,7 @@ const guessBranch = (): string | undefined => {
         .map(({ name }) => name)
         .join(
           ", "
-        )}). Please specify your target branch explicitly instead, e.g. ESLINT_PLUGIN_COMMIT="main"`
+        )}). Please specify your target branch explicitly instead, e.g. ESLINT_PLUGIN_DIFF_COMMIT="main"`
     );
   }
 


### PR DESCRIPTION
## Summary
- fix environment variable name to `ESLINT_PLUGIN_DIFF_COMMIT`
- update CI tests accordingly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686395b00074832abceea0c14eb3cf97